### PR TITLE
bash is there, why not to use it?

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,5 @@ COPY ./conf/php-fpm.conf /etc/php/
 
 VOLUME /export/htdocs/
 
-CMD ["/bin/sh"]
-ENTRYPOINT ["/bin/sh", "-c"]
+CMD ["/bin/bash"]
+ENTRYPOINT ["/bin/bash", "-c"]


### PR DESCRIPTION
Or perhaps, `bash` should be removed from the apk list?
